### PR TITLE
fix https://github.com/roboflow-ai/notebooks/issues/22

### DIFF
--- a/notebooks/train-yolos-huggingface-object-detection-on-custom-data.ipynb
+++ b/notebooks/train-yolos-huggingface-object-detection-on-custom-data.ipynb
@@ -19476,7 +19476,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install -q transformers\n",
+        "!pip install -q transformers==4.20.0\n",
         "!pip install -q pytorch-lightning\n",
         "!pip install -q wandb\n",
         "!pip install -q roboflow\n",


### PR DESCRIPTION
# Description

The issue was caused by braking changes in `transformers` pip package. I went back in time and pinpointed the specific version of version of library that was latest at the time of recording YouTube video. 